### PR TITLE
android switch to sdk version 21

### DIFF
--- a/RNBluetoothStateManager.podspec
+++ b/RNBluetoothStateManager.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNBluetoothStateManager"
-  s.version      = "0.0.0-development"
+  s.version      = "2.0.0"
   s.summary      = "RNBluetoothStateManager"
   s.description  = <<-DESC
                   RNBluetoothStateManager

--- a/RNBluetoothStateManager.podspec
+++ b/RNBluetoothStateManager.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.version      = "2.0.0"
   s.summary      = "RNBluetoothStateManager"
   s.description  = <<-DESC
-                  RNBluetoothStateManager
+                  RNBluetoothStateManager handle bluetooth state
                    DESC
   s.homepage     = "https://github.com/patlux/react-native-bluetooth-state-manager"
   s.license      = "MIT"

--- a/RNBluetoothStateManager.podspec
+++ b/RNBluetoothStateManager.podspec
@@ -1,4 +1,3 @@
-
 Pod::Spec.new do |s|
   s.name         = "RNBluetoothStateManager"
   s.version      = "2.0.0"
@@ -6,11 +5,11 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNBluetoothStateManager handle bluetooth state
                    DESC
-  s.homepage     = "https://github.com/patlux/react-native-bluetooth-state-manager"
+  s.homepage     = "https://github.com/nitrique/react-native-bluetooth-state-manager"
   s.license      = "MIT"
   s.author       = { "author" => "email@patwoz.de" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/patlux/react-native-bluetooth-state-manager.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/nitrique/react-native-bluetooth-state-manager.git", :tag => "master" }
   s.source_files = "ios/*.{h,m}"
   s.requires_arc = true
 
@@ -19,4 +18,3 @@ Pod::Spec.new do |s|
   #s.dependency "others"
 
 end
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ android {
     buildToolsVersion "27.0.3"
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.1.0"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -25,7 +25,7 @@ allprojects {
     }
     project.ext {
         myBuildToolsVersion="27.0.3"
-        myMinSdkVersion=18 /* = 4.1 Jelly Bean */
+        myMinSdkVersion=21 /* = 5.0 Lollipop */
         myTargetSdkVersion=27 /* = 8.1 Oreo */
         myCompileSdkVersion=27 /* = 8.1 Oreo */
         myAppCompatVersion="27.1.1"

--- a/ios/RNBluetoothStateManager.xcodeproj/project.pbxproj
+++ b/ios/RNBluetoothStateManager.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -156,7 +157,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -193,7 +194,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -204,7 +205,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				"$(inherited)",
+					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",


### PR DESCRIPTION
Hi,
 
React Native 0.64 need a minimum version of 21 for the android Sdk.
This is a breaking change so I guess major version should be upgraded

Regards,
Nicolas