### PR TITLE
#59 fix onStateChange type declaration

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,5 @@
+import { EventSubscription } from "react-native";
+
 declare module 'react-native-bluetooth-state-manager' {
   type BluetoothState =
     | 'Unknown'
@@ -11,7 +13,7 @@ declare module 'react-native-bluetooth-state-manager' {
   function onStateChange(
     listener: (bluetoothState: BluetoothState) => void,
     emitCurrentState: boolean
-  ): Promise<string>;
+  ): EventSubscription;
   function openSettings(): Promise<null>;
   function requestToEnable(): Promise<Boolean>;
   function enable(): Promise<null>;


### PR DESCRIPTION
`onStateChange` has an incorrect type declaration which breaks TS usage forcing us to ignore the type