### PR TITLE
Format types with prettier

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-import { EventSubscription } from "react-native";
+import { EventSubscription } from 'react-native';
 
 declare module 'react-native-bluetooth-state-manager' {
   type BluetoothState =


### PR DESCRIPTION
Types were updated in https://github.com/patlux/react-native-bluetooth-state-manager/pull/71 but not matching prettier's setup.
This PR fixes the format of the types by running `npm run format`.