### PR TITLE
Fix warnings for EventEmitter

### DIFF
--- a/android/src/main/java/de/patwoz/rn/bluetoothstatemanager/RNBluetoothStateManagerModule.java
+++ b/android/src/main/java/de/patwoz/rn/bluetoothstatemanager/RNBluetoothStateManagerModule.java
@@ -115,6 +115,14 @@ public class RNBluetoothStateManagerModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void addListener(String eventName) {
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+  }
+
+  @ReactMethod
   public void disable(Promise promise) {
     if (this.handleIfBluetoothNotSupported(promise)) { return; }
     Activity currentActivity = this.handleCurrentActivity(promise);

--- a/android/src/main/java/de/patwoz/rn/bluetoothstatemanager/RNBluetoothStateManagerModule.java
+++ b/android/src/main/java/de/patwoz/rn/bluetoothstatemanager/RNBluetoothStateManagerModule.java
@@ -115,12 +115,10 @@ public class RNBluetoothStateManagerModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void addListener(String eventName) {
-  }
+  public void addListener(String eventName) {}
 
   @ReactMethod
-  public void removeListeners(Integer count) {
-  }
+  public void removeListeners(Integer count) {}
 
   @ReactMethod
   public void disable(Promise promise) {


### PR DESCRIPTION
To avoid the warnings mentioned in #60 I've added the two missing functions that should be added according to: https://github.com/facebook/react-native/blob/main/Libraries/EventEmitter/NativeEventEmitter.js.

